### PR TITLE
fix: use prefixed encoding for multicodec

### DIFF
--- a/src/Utils/sign-helpers.ts
+++ b/src/Utils/sign-helpers.ts
@@ -14,7 +14,7 @@ export const createHash = async (blob: ArrayBuffer | null): Promise<string> => {
   if (!blob) throw new Error('No File given')
   const blobAsU8a = new Uint8Array(blob)
   const hash = await sha56.digest(blobAsU8a)
-  return base16.baseEncode(hash.bytes)
+  return base16.encode(hash.bytes)
 }
 
 const sporranWindow = window.kilt || {}


### PR DESCRIPTION
Not sure if this is really what was expected, but calling `base16.baseEncode(hash.bytes)` simply encodes the hash as base-16 **without** the multiencode prefix. Since the encoder is used from the multiformats repo, I assume that the expected result is to have the encoding **with** the multiencode prefix, which can be obtained by replacing `baseEncode` with `encode`.
If this change is merged, probably additional checks must be done at the decoding site to be retro-compatible, i.e., verify whether the encoding is a multiencode, and if not try to simply decode it as base16, as it is done now.