### PR TITLE
fix: only show subscan link if target known

### DIFF
--- a/src/components/DidDocument/DidDocument.tsx
+++ b/src/components/DidDocument/DidDocument.tsx
@@ -71,7 +71,7 @@ export function DidDocument({ signDoc }: { signDoc: SignDoc }) {
         <span className={styles.title}>Signed At</span>
         <span className={styles.text}>
           {timestamp || 'No timestamp available'}
-          {remark && (
+          {remark && subscanHost && (
             <a
               className={styles.subscan}
               href={`${subscanHost}/extrinsic/${remark.txHash}`}

--- a/src/hooks/useSubscanHost.ts
+++ b/src/hooks/useSubscanHost.ts
@@ -2,11 +2,12 @@ const subscanHosts: Record<string, string | undefined> = {
   'wss://peregrine.kilt.io': 'https://kilt-testnet.subscan.io',
   'wss://spiritnet.kilt.io': 'https://spiritnet.subscan.io',
   'wss://kilt-rpc.dwellir.com': 'https://spiritnet.subscan.io',
+  'wss://spiritnet.api.onfinality.io': 'https://spiritnet.subscan.io',
 };
 
 export function useSubscanHost(): string | undefined {
   const kiltEndpoint =
     process.env.REACT_APP_CHAIN_ENDPOINT || 'wss://spiritnet.kilt.io';
 
-  return subscanHosts[kiltEndpoint];
+  return subscanHosts[new URL(kiltEndpoint).origin];
 }


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3176

Page was trying to show a URL to Subscan even when on Subscan instance was matched based on the full node URL. This has been fixed. Also added the missing full node to the list of known nodes.